### PR TITLE
Fix offsetting to start of buffer on empty offset function

### DIFF
--- a/origami-util.el
+++ b/origami-util.el
@@ -217,8 +217,9 @@ Argument TYPE see function `origami-util-string-compare-p' for more information.
 (defun origami-util-function-offset (fnc beg match)
   "Call FNC starting from BEG.
 Argument MATCH is for callback."
-  (let ((result (save-excursion
-                  (goto-char beg) (- (or (and fnc (funcall fnc match)) 0) beg))))
+  (let ((result (if (not fnc) (length match)
+                  (save-excursion (goto-char beg)
+                                  (- (funcall fnc match) beg)))))
     (unless result
       (user-error "Something went wrong while offsetting region: `%s` at `%s`" match beg))
     result))


### PR DESCRIPTION
Hi,

I had a problem with xml folding, it would start every fold at the start of buffer, while the end of the fold looked reasonable. Looking at the code, I think this is the case for every caller to `origami-build-pair-tree` that leaves `fnc-offset` empty.

I wrote a quick fix to `origami-util-function-offset`, but it might require some discussion and/or refactoring:

### Fix
If arg `fnc` is nil, the function would return pos `0 - beg`, which is the start of the buffer.

If arg `fnc` is empty, we want some sensible default behavior. `beg` is the start of the beginning match. Usually we want it to remain visible, and start folding right after it, so offset `length(match)` sounds sensible.

### Discussion
Looking at the call sites of `origami-util-function-offset`, this used to be done by `or` at the call site, where `origami-util-function-offset` used to return nil when the offset function argument `fnc` was nil in prior versions (using `ignore-errors`). E.g. here in `origami-build-pair-tree`:
```
(or (origami-util-function-offset fnc-offset beg-pos beg-match)
    (length beg-match))
```
The call site in `origami-build-pair-tree-2` works the same way I think, not sure though.

Now `origami-util-function-offset` will never return nil, we either pass a `fnc-pos`, or we get some default behaviour (which cannot be determined by call site anymore), seems fine to me.

If that's the intent, I think the call-site fallback code can be safely removed (no more `or`). What do you think?